### PR TITLE
feat(graph): add animated edges with a button that control the animation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ importers:
         specifier: 1.27.0
         version: 1.27.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@xyflow/react':
-        specifier: ^12.6.0
+        specifier: 12.6.0
         version: 12.6.0(@types/react@18.2.66)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       class-variance-authority:
         specifier: 0.7.1

--- a/src/features/graph/animated-controls.tsx
+++ b/src/features/graph/animated-controls.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+
+interface AnimationControlsProps {
+  onToggleAnimation: (isAnimating: boolean) => void;
+}
+
+export default function AnimationControls({ onToggleAnimation }: AnimationControlsProps) {
+  const [isAnimating, setIsAnimating] = useState(false);
+
+  const handleClick = () => {
+    const newState = !isAnimating;
+    setIsAnimating(newState);
+    onToggleAnimation(newState);
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className="absolute top-4 right-4 z-10 px-4 py-2 bg-blue-500 text-white rounded-lg shadow hover:bg-blue-600 transition-colors"
+    >
+      {isAnimating ? 'Stop Animation' : 'Start Animation'}
+    </button>
+  );
+}

--- a/src/features/graph/animated-edge.tsx
+++ b/src/features/graph/animated-edge.tsx
@@ -1,0 +1,53 @@
+import { EdgeProps, getBezierPath } from '@xyflow/react';
+
+interface AnimatedEdgeProps extends EdgeProps {
+  data?: {
+    isAnimating?: boolean;
+  };
+}
+
+export default function AnimatedEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  style = {},
+  markerEnd,
+  data,
+}: AnimatedEdgeProps) {
+  const [edgePath] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  return (
+    <>
+      <path
+        id={id}
+        style={style}
+        className="react-flow__edge-path"
+        d={edgePath}
+        markerEnd={markerEnd}
+      />
+      <path
+        d={edgePath}
+        fill="none"
+        strokeWidth={2}
+        className="animated-edge"
+        style={{
+          stroke: '#b1b1b7',
+          strokeDasharray: 5,
+          animation: data?.isAnimating ? 'dashdraw 0.5s linear infinite' : 'none',
+          opacity: data?.isAnimating ? 1 : 0,
+        }}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
Added edge animation in the graph with a controller button that could later be mapped to the ai flow build action.

Place components in a graph folder in the components folder.

Fix specifier: ^12.6.0 for 12.6.0 in pnpm-lock.yarn