### PR TITLE
[FEAT] Canva: Main agent node

### DIFF
--- a/src/const/dss-left-panel.tsx
+++ b/src/const/dss-left-panel.tsx
@@ -1,12 +1,7 @@
 import AIAgentIcon from '@/assets/icons/ai-agent';
-import AIPromptIcon from '@/assets/icons/ai-prompt';
-import DataTableRowIcon from '@/assets/icons/data-table-row';
-import DatasetIcon from '@/assets/icons/dataset';
-import KnowledgeBankIcon from '@/assets/icons/knowledge-bank';
 import LLMIcon from '@/assets/icons/llm';
-import ModelizeIcon from '@/assets/icons/modelize';
 import ToolWrenchIcon from '@/assets/icons/tool-wrench';
-import UserEmailIcon from '@/assets/icons/user-email';
+
 export const DSSLeftPanelMenus = [
   {
     id: 'tools',
@@ -27,104 +22,3 @@ export const DSSLeftPanelMenus = [
     color: '#D66F9E',
   },
 ];
-
-export const DSSLeftPanelNodes = {
-  tools: [
-    {
-      id: 'lookup-dataset',
-      name: 'Lookup Dataset',
-      desc: 'Find a record based on conditions on one or several columns',
-      icon: <DatasetIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
-      color: 'cyan-blue-base',
-    },
-    {
-      id: 'search-knowledge-bank',
-      name: 'Search Knowledge Bank',
-      desc: 'Search a Knowledge Bank for relevant information',
-      icon: <KnowledgeBankIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
-      color: 'cyan-blue-base',
-    },
-    {
-      id: 'call-from-llm-mesh',
-      name: 'Call from LLM Mesh',
-      desc: 'Send a request to an LLM or Agent registered in the LLM Mesh',
-      icon: <AIPromptIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
-      color: 'cyan-blue-base',
-    },
-    {
-      id: 'append-to-dataset',
-      name: 'Append to Dataset',
-      desc: 'Search a Knowledge Bank for relevant information',
-      icon: <DataTableRowIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
-      color: 'cyan-blue-base',
-    },
-    {
-      id: 'send-message',
-      name: 'Send message',
-      desc: 'Send a message through a Dataiku Messaging Channel (email, Slack,…) ',
-      icon: <UserEmailIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
-      color: 'cyan-blue-base',
-    },
-    {
-      id: 'model-predict',
-      name: 'Model Predict',
-      desc: 'Predict a record from a dataset with a Dataiku model',
-      icon: <ModelizeIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
-      color: 'cyan-blue-base',
-    },
-  ],
-  agents: [
-    {
-      id: 'agent-1',
-      name: 'Agent 1',
-      desc: 'Description for Agent 1',
-      icon: (
-        <div className="w-6 h-6 p-0 m-0 bg-pink-base flex items-center justify-center rotate-45">
-          <AIAgentIcon className="size-4 text-white -rotate-45" />
-        </div>
-      ),
-      color: 'green-base',
-    },
-    {
-      id: 'agent-2',
-      name: 'Agent 2',
-      desc: 'Description for Agent 2',
-      icon: (
-        <div className="w-6 h-6 bg-pink-base flex items-center justify-center rotate-45">
-          <AIAgentIcon className="size-4 text-white -rotate-45" />
-        </div>
-      ),
-      color: 'green-base',
-    },
-  ],
-  llm: [
-    {
-      id: 'openai',
-      name: 'OpenAI',
-      desc: 'Description for LLM 1',
-      icon: <img src="./src/assets/logo/openai.png" alt="OpenAI" className="w-4 h-4 mr-1" />,
-      color: '#D66F9E',
-    },
-    {
-      id: 'anthropic',
-      name: 'Anthropic',
-      desc: 'Description for LLM 2',
-      icon: <img src="./src/assets/logo/anthropic.png" alt="Anthropic" className="w-4 h-4 mr-1" />,
-      color: '#D66F9E',
-    },
-    {
-      id: 'mistral',
-      name: 'Mistral',
-      desc: 'Description for LLM 3',
-      icon: <img src="./src/assets/logo/mistral.png" alt="Mistral" className="w-4 h-4 mr-1" />,
-      color: '#D66F9E',
-    },
-    {
-      id: 'meta',
-      name: 'Meta',
-      desc: 'Description for LLM 4',
-      icon: <img src="./src/assets/logo/meta.png" alt="Meta" className="w-4 h-4 mr-1" />,
-      color: '#D66F9E',
-    },
-  ],
-};

--- a/src/const/nodes.tsx
+++ b/src/const/nodes.tsx
@@ -1,0 +1,108 @@
+import AIAgentIcon from '@/assets/icons/ai-agent';
+import AIPromptIcon from '@/assets/icons/ai-prompt';
+import DataTableRowIcon from '@/assets/icons/data-table-row';
+import DatasetIcon from '@/assets/icons/dataset';
+import KnowledgeBankIcon from '@/assets/icons/knowledge-bank';
+import ModelizeIcon from '@/assets/icons/modelize';
+import UserEmailIcon from '@/assets/icons/user-email';
+
+export const NODES = {
+  tools: [
+    {
+      id: 'lookup-dataset',
+      name: 'Lookup Dataset',
+      desc: 'Find a record based on conditions on one or several columns',
+      icon: <DatasetIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
+      color: 'cyan-blue-base',
+    },
+    {
+      id: 'search-knowledge-bank',
+      name: 'Search Knowledge Bank',
+      desc: 'Search a Knowledge Bank for relevant information',
+      icon: <KnowledgeBankIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
+      color: 'cyan-blue-base',
+    },
+    {
+      id: 'call-from-llm-mesh',
+      name: 'Call from LLM Mesh',
+      desc: 'Send a request to an LLM or Agent registered in the LLM Mesh',
+      icon: <AIPromptIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
+      color: 'cyan-blue-base',
+    },
+    {
+      id: 'append-to-dataset',
+      name: 'Append to Dataset',
+      desc: 'Search a Knowledge Bank for relevant information',
+      icon: <DataTableRowIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
+      color: 'cyan-blue-base',
+    },
+    {
+      id: 'send-message',
+      name: 'Send message',
+      desc: 'Send a message through a Dataiku Messaging Channel (email, Slack,…) ',
+      icon: <UserEmailIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
+      color: 'cyan-blue-base',
+    },
+    {
+      id: 'model-predict',
+      name: 'Model Predict',
+      desc: 'Predict a record from a dataset with a Dataiku model',
+      icon: <ModelizeIcon className="size-6 text-white bg-green-base rounded-full p-1" />,
+      color: 'cyan-blue-base',
+    },
+  ],
+  agents: [
+    {
+      id: 'agent-1',
+      name: 'Agent 1',
+      desc: 'Description for Agent 1',
+      icon: (
+        <div className="w-6 h-6 p-0 m-0 bg-pink-base flex items-center justify-center rotate-45">
+          <AIAgentIcon className="size-4 text-white -rotate-45" />
+        </div>
+      ),
+      color: 'green-base',
+    },
+    {
+      id: 'agent-2',
+      name: 'Agent 2',
+      desc: 'Description for Agent 2',
+      icon: (
+        <div className="w-6 h-6 bg-pink-base flex items-center justify-center rotate-45">
+          <AIAgentIcon className="size-4 text-white -rotate-45" />
+        </div>
+      ),
+      color: 'green-base',
+    },
+  ],
+  llm: [
+    {
+      id: 'openai',
+      name: 'OpenAI',
+      desc: 'Description for LLM 1',
+      icon: <img src="./src/assets/logo/openai.png" alt="OpenAI" className="w-4 h-4 mr-1" />,
+      color: '#D66F9E',
+    },
+    {
+      id: 'anthropic',
+      name: 'Anthropic',
+      desc: 'Description for LLM 2',
+      icon: <img src="./src/assets/logo/anthropic.png" alt="Anthropic" className="w-4 h-4 mr-1" />,
+      color: '#D66F9E',
+    },
+    {
+      id: 'mistral',
+      name: 'Mistral',
+      desc: 'Description for LLM 3',
+      icon: <img src="./src/assets/logo/mistral.png" alt="Mistral" className="w-4 h-4 mr-1" />,
+      color: '#D66F9E',
+    },
+    {
+      id: 'meta',
+      name: 'Meta',
+      desc: 'Description for LLM 4',
+      icon: <img src="./src/assets/logo/meta.png" alt="Meta" className="w-4 h-4 mr-1" />,
+      color: '#D66F9E',
+    },
+  ],
+};

--- a/src/features/canva/index.tsx
+++ b/src/features/canva/index.tsx
@@ -28,6 +28,7 @@ const initialNodes: Node[] = [
     type: 'main-agent',
     data: { title: 'Main Agent' },
     position: { x: 0, y: 0 },
+    draggable: false,
   },
 ];
 

--- a/src/features/canva/index.tsx
+++ b/src/features/canva/index.tsx
@@ -1,4 +1,5 @@
 import '@xyflow/react/dist/style.css';
+import '@/index.css';
 
 import {
   addEdge,
@@ -19,14 +20,20 @@ import { DnDProvider } from '@/context/DnDContext';
 import AnimationControls from '@/features/graph/animated-controls';
 import AnimatedEdge from '@/features/graph/animated-edge';
 
+import MainAgentNode from './nodes/main-agent';
+
 const initialNodes: Node[] = [
   {
     id: '1',
-    type: 'input',
-    data: { label: 'input node' },
-    position: { x: 250, y: 5 },
+    type: 'main-agent',
+    data: { title: 'Main Agent' },
+    position: { x: 0, y: 0 },
   },
 ];
+
+// we define the nodeTypes outside of the component to prevent re-renderings
+// you could also use useMemo inside the component
+const nodeTypes = { 'main-agent': MainAgentNode };
 
 let id = 0;
 const getId = () => `dndnode_${id++}`;
@@ -105,6 +112,7 @@ const DnDFlow = () => {
           onDrop={onDrop}
           onDragOver={onDragOver}
           edgeTypes={edgeTypes}
+          nodeTypes={nodeTypes}
           fitView
           style={{ width: '100%', height: '100%' }}
         >

--- a/src/features/canva/nodes/main-agent.tsx
+++ b/src/features/canva/nodes/main-agent.tsx
@@ -1,0 +1,45 @@
+import { Handle, Node, NodeProps, Position } from '@xyflow/react';
+
+import AIAgentIcon from '@/assets/icons/ai-agent';
+
+type MainAgentNodeData = { title: string };
+type MainAgentNodeType = Node<MainAgentNodeData, 'main-agent'>;
+
+const MainAgentNode: React.FC<NodeProps<MainAgentNodeType>> = ({ data, isConnectable }) => {
+  return (
+    <div className="bg-white border border-pink-base rounded-lg px-5 py-4">
+      <div className="flex flex-row gap-4 items-center justify-center">
+        <div className="p-2 bg-pink-base flex items-center justify-center rotate-45">
+          <AIAgentIcon className="size-5 text-white -rotate-45" />
+        </div>
+        <p>{data.title}</p>
+      </div>
+      <Handle
+        type="target"
+        className="!bg-pink-base !size-3 rounded-full"
+        position={Position.Top}
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="target"
+        className="!bg-pink-base !size-3 rounded-full"
+        position={Position.Left}
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        className="!bg-pink-base !size-3 rounded-full"
+        position={Position.Right}
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        className="!bg-pink-base !size-3 rounded-full"
+        position={Position.Bottom}
+        isConnectable={isConnectable}
+      />
+    </div>
+  );
+};
+
+export default MainAgentNode;

--- a/src/features/left-panel/index.tsx
+++ b/src/features/left-panel/index.tsx
@@ -2,7 +2,8 @@ import { ChevronLeft, Search } from 'lucide-react';
 import { useState } from 'react';
 
 import { Input } from '@/components/ui/input';
-import { DSSLeftPanelMenus, DSSLeftPanelNodes } from '@/const/dss-left-panel';
+import { DSSLeftPanelMenus } from '@/const/dss-left-panel';
+import { NODES } from '@/const/nodes';
 import { MenuItem } from '@/features/left-panel/components/menu-item';
 import { NodeItem } from '@/features/left-panel/components/node-item';
 
@@ -53,7 +54,7 @@ export const LeftPanel = () => {
       ) : (
         <div className="flex flex-col h-full">
           <div className="flex-1 overflow-y-auto p-2 flex flex-col gap-2">
-            {DSSLeftPanelNodes[selectedMenu as keyof typeof DSSLeftPanelNodes].map((node) => (
+            {NODES[selectedMenu as keyof typeof NODES].map((node) => (
               <NodeItem
                 key={node.id}
                 label={node.name}


### PR DESCRIPTION
This pull request refactors the left panel and node management in the application to improve modularity and maintainability. The changes include moving node definitions to a new `NODES` constant, introducing a custom node type (`MainAgentNode`), and updating the left panel to use the new `NODES` structure.

### Refactoring for Node Management:

* Moved node definitions from `DSSLeftPanelNodes` in `src/const/dss-left-panel.tsx` to a new `NODES` constant in `src/const/nodes.tsx`. This improves modularity by separating node definitions from menu configurations. (`[[1]](diffhunk://#diff-0d8f51d24e2022b0e57aba539a97003ed2a3e1c8bf4b3661b709d257c57d8a8bL30-L130)`, `[[2]](diffhunk://#diff-2779c440ccae8887b15dc2cbfef542dbad70d2c7002bcdf4d5d6180c549e6121R1-R108)`)
* Updated references in `src/features/left-panel/index.tsx` to use the new `NODES` constant instead of `DSSLeftPanelNodes`. (`[[1]](diffhunk://#diff-148507f8d1d3b5b11bd31a6695ec1ca6c4d0c3a62afb80317f9712c52025f10fL5-R6)`, `[[2]](diffhunk://#diff-148507f8d1d3b5b11bd31a6695ec1ca6c4d0c3a62afb80317f9712c52025f10fL56-R57)`)

### Custom Node Type:

* Added a new custom node type, `MainAgentNode`, in `src/features/canva/nodes/main-agent.tsx`. This node includes a styled design and multiple connection handles for better usability. (`[src/features/canva/nodes/main-agent.tsxR1-R45](diffhunk://#diff-8ace8568205b12af56a97633bea8232fbfe279cdd67933b941322ba49b0ac50eR1-R45)`)
* Integrated the `MainAgentNode` into the canvas by defining it in `nodeTypes` and passing it to the `ReactFlow` component in `src/features/canva/index.tsx`. (`[[1]](diffhunk://#diff-016660b1b54ab716b08d79b2300f8287a324c4d41d542083b4ea9f5489e9cc24R23-R37)`, `[[2]](diffhunk://#diff-016660b1b54ab716b08d79b2300f8287a324c4d41d542083b4ea9f5489e9cc24R115)`)

### Miscellaneous:

* Added a global CSS import (`@/index.css`) to `src/features/canva/index.tsx` for consistent styling. (`[src/features/canva/index.tsxR2](diffhunk://#diff-016660b1b54ab716b08d79b2300f8287a324c4d41d542083b4ea9f5489e9cc24R2)`)