### PR TITLE
[FEAT] Canva: Implementing the agent node

### DIFF
--- a/src/features/canva/index.tsx
+++ b/src/features/canva/index.tsx
@@ -21,6 +21,7 @@ import { DnDProvider } from '@/context/DnDContext';
 import AnimationControls from '@/features/graph/animated-controls';
 import AnimatedEdge from '@/features/graph/animated-edge';
 
+import AgentNode from './nodes/agent';
 import MainAgentNode from './nodes/main-agent';
 import ToolNode from './nodes/tool';
 
@@ -36,7 +37,7 @@ const initialNodes: Node[] = [
 
 // we define the nodeTypes outside of the component to prevent re-renderings
 // you could also use useMemo inside the component
-const nodeTypes = { 'main-agent': MainAgentNode, tool: ToolNode };
+const nodeTypes = { 'main-agent': MainAgentNode, tool: ToolNode, agent: AgentNode };
 
 let id = 0;
 const getId = () => `dndnode_${id++}`;

--- a/src/features/canva/nodes/agent.tsx
+++ b/src/features/canva/nodes/agent.tsx
@@ -1,0 +1,31 @@
+import { Handle, Node, NodeProps, Position } from '@xyflow/react';
+
+import NodeIcon from '@/components/node-icons';
+import { NodeType } from '@/const/nodes';
+
+type AgentNodeType = Node<NodeType, 'agent'>;
+
+const AgentNode: React.FC<NodeProps<AgentNodeType>> = ({ data, isConnectable }) => {
+  return (
+    <div className="bg-white border rounded-full px-3 py-3 border-gray-300">
+      <div className="flex flex-row gap-2 items-center justify-center">
+        <NodeIcon name={data.icon} />
+        <p>{data.name}</p>
+      </div>
+      <Handle
+        type="source"
+        className="!bg-gray-400 !size-2 rounded-full"
+        position={Position.Left}
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        className="!bg-gray-400 !size-2 rounded-full"
+        position={Position.Right}
+        isConnectable={isConnectable}
+      />
+    </div>
+  );
+};
+
+export default AgentNode;

--- a/src/features/canva/nodes/tool.tsx
+++ b/src/features/canva/nodes/tool.tsx
@@ -7,8 +7,8 @@ type ToolNodeType = Node<NodeType, 'tool'>;
 
 const ToolNode: React.FC<NodeProps<ToolNodeType>> = ({ data, isConnectable }) => {
   return (
-    <div className="bg-white border border-pink-base rounded-full px-5 py-4">
-      <div className="flex flex-row gap-4 items-center justify-center">
+    <div className="bg-white border rounded-full px-3 py-2 border-gray-300">
+      <div className="flex flex-row gap-2 items-center justify-center">
         <NodeIcon name={data.icon} />
         <p>{data.name}</p>
       </div>
@@ -20,7 +20,7 @@ const ToolNode: React.FC<NodeProps<ToolNodeType>> = ({ data, isConnectable }) =>
       />
       <Handle
         type="source"
-        className="!bg-gray-400 !size-3 rounded-full"
+        className="!bg-gray-400 !size-2 rounded-full"
         position={Position.Right}
         isConnectable={isConnectable}
       />


### PR DESCRIPTION
This pull request introduces a new `AgentNode` component to the canvas feature and updates the styling and configuration of the existing `ToolNode` component. The changes include the addition of a new node type, adjustments to node styles, and modifications to node connection handles.

### Addition of `AgentNode` Component:

* **New `AgentNode` Component Added**: Created a new `AgentNode` component in `src/features/canva/nodes/agent.tsx`. This component includes a customizable icon and name, with connection handles on both the left and right sides.
* **Integration of `AgentNode` into Node Types**: Updated the `nodeTypes` object in `src/features/canva/index.tsx` to include the new `agent` node type, enabling its use in the canvas.
* **Import Statement for `AgentNode`**: Added the import for `AgentNode` in `src/features/canva/index.tsx`.

### Updates to `ToolNode` Component:

* **Styling Adjustments**: Modified the `ToolNode` component's styles to align more closely with the `AgentNode`. Changes include smaller padding, updated border styles, and reduced spacing between elements.
* **Handle Size Update**: Reduced the size of the connection handle on the right side of the `ToolNode` component for consistency with the `AgentNode`.