### PR TITLE
feat(canva): implementing the llm nodes

### DIFF
--- a/src/features/canva/index.tsx
+++ b/src/features/canva/index.tsx
@@ -22,6 +22,7 @@ import AnimationControls from '@/features/graph/animated-controls';
 import AnimatedEdge from '@/features/graph/animated-edge';
 
 import AgentNode from './nodes/agent';
+import LLMNode from './nodes/llm';
 import MainAgentNode from './nodes/main-agent';
 import ToolNode from './nodes/tool';
 
@@ -37,7 +38,7 @@ const initialNodes: Node[] = [
 
 // we define the nodeTypes outside of the component to prevent re-renderings
 // you could also use useMemo inside the component
-const nodeTypes = { 'main-agent': MainAgentNode, tool: ToolNode, agent: AgentNode };
+const nodeTypes = { 'main-agent': MainAgentNode, tool: ToolNode, agent: AgentNode, llm: LLMNode };
 
 let id = 0;
 const getId = () => `dndnode_${id++}`;

--- a/src/features/canva/nodes/llm.tsx
+++ b/src/features/canva/nodes/llm.tsx
@@ -1,0 +1,31 @@
+import { Handle, Node, NodeProps, Position } from '@xyflow/react';
+
+import NodeIcon from '@/components/node-icons';
+import { NodeType } from '@/const/nodes';
+
+type LLMNodeType = Node<NodeType, 'llm'>;
+
+const LLMNode: React.FC<NodeProps<LLMNodeType>> = ({ data, isConnectable }) => {
+  return (
+    <div className="bg-white border rounded-full px-3 py-2 border-gray-300">
+      <div className="flex flex-row gap-2 items-center justify-center">
+        <NodeIcon name={data.icon} />
+        <p>{data.name}</p>
+      </div>
+      <Handle
+        type="source"
+        className="!bg-gray-400 !size-2 rounded-full"
+        position={Position.Left}
+        isConnectable={isConnectable}
+      />
+      <Handle
+        type="source"
+        className="!bg-gray-400 !size-2 rounded-full"
+        position={Position.Right}
+        isConnectable={isConnectable}
+      />
+    </div>
+  );
+};
+
+export default LLMNode;


### PR DESCRIPTION
This pull request introduces a new `LLMNode` component to the canvas feature, enabling support for a new node type in the graph. The changes include adding the `LLMNode` implementation, updating the node types configuration, and importing the new component.

### New Node Type: `LLMNode`

* **Implementation of `LLMNode` Component**: Added the `LLMNode` component in `src/features/canva/nodes/llm.tsx`. This component defines the structure and behavior of the new node type, including its appearance and connection handles.

* **Importing `LLMNode`**: Imported the newly created `LLMNode` component into the canvas feature (`src/features/canva/index.tsx`).

* **Updating Node Types Configuration**: Extended the `nodeTypes` object in `src/features/canva/index.tsx` to include the new `llm` node type, mapping it to the `LLMNode` component.