### PR TITLE
[FEAT] Canva: Adding complex agents

### DIFF
--- a/src/const/nodes.tsx
+++ b/src/const/nodes.tsx
@@ -88,6 +88,17 @@ export const NODES: {
   ],
   agents: [
     {
+      id: 'meeting-prep',
+      type: 'agent',
+      name: 'Meeting Prep',
+      desc: 'Prepare a meeting, return any information you have and search the knowledge base for any project that could be related',
+      icon: 'agent',
+      config: {
+        llm: 'openai',
+        instructions: '',
+      },
+    },
+    {
       id: 'text-summarization',
       type: 'agent',
       name: 'Text Summarization',

--- a/src/features/canva/complex/meeting-prep.tsx
+++ b/src/features/canva/complex/meeting-prep.tsx
@@ -1,0 +1,152 @@
+import { Edge, Node } from '@xyflow/react';
+
+export function meetingPrepNodes(id: string) {
+  function addNewID(s: string): string {
+    return s.replace(/(dndnode_\d+)/g, `$1_${id}`);
+  }
+
+  const nodes: Node[] = NODES.map((node) => {
+    return {
+      ...node,
+      id: addNewID(node.id),
+    };
+  });
+
+  const edges: Edge[] = EDGES.map((edge) => ({
+    ...edge,
+    source: addNewID(edge.source),
+    sourceHandle: addNewID(edge.sourceHandle || ''),
+    target: addNewID(edge.target),
+    targetHandle: addNewID(edge.targetHandle || ''),
+  }));
+
+  return { nodes, edges };
+}
+
+const NODES: Node[] = [
+  {
+    id: 'dndnode_0',
+    type: 'agent',
+    position: {
+      x: 115.23860777795898,
+      y: -145.52671092193998,
+    },
+    data: {
+      id: 'meeting-prep',
+      type: 'agent',
+      name: 'Meeting Prep',
+      desc: 'Prepare a meeting, return any information you have and search the knowledge base for any project that could be related',
+      icon: 'agent',
+      config: {
+        llm: 'openai',
+        instructions:
+          'Please retrieve relevant information from the meeting history and search through the project knowledge base (KB) to compile comprehensive meeting preparation notes. Ensure the notes include key discussion points, updates on current projects, action items, and any relevant background information for the upcoming meeting.',
+      },
+      isSelected: false,
+    },
+    measured: {
+      width: 155,
+      height: 50,
+    },
+    selected: false,
+    dragging: false,
+  },
+  {
+    id: 'dndnode_1',
+    type: 'tool',
+    position: {
+      x: -167.20872107772436,
+      y: -183.14470428619157,
+    },
+    data: {
+      id: 'lookup-dataset',
+      type: 'tool',
+      name: 'LookupMeetingHistory',
+      desc: 'Find a record based on conditions on one or several columns',
+      icon: 'dataset',
+      isSelected: false,
+    },
+    measured: {
+      width: 222,
+      height: 42,
+    },
+    selected: false,
+    dragging: false,
+  },
+  {
+    id: 'dndnode_2',
+    type: 'tool',
+    position: {
+      x: -128.8231945272263,
+      y: -96.00973636132444,
+    },
+    data: {
+      id: 'search-knowledge-bank',
+      type: 'tool',
+      name: 'SearchProjectKB',
+      desc: 'Search a Knowledge Bank for relevant information',
+      icon: 'knowledge-bank',
+      isSelected: false,
+    },
+    measured: {
+      width: 180,
+      height: 42,
+    },
+    selected: false,
+    dragging: false,
+  },
+  {
+    id: 'dndnode_3',
+    type: 'tool',
+    position: {
+      x: 342.00974118595144,
+      y: -141.15161112541847,
+    },
+    data: {
+      id: 'call-from-llm-mesh',
+      type: 'tool',
+      name: 'CallPrepAgent',
+      desc: 'Send a request to an LLM or Agent registered in the LLM Mesh',
+      icon: 'ai-prompt',
+      isSelected: false,
+      config: {
+        'llm-agent': 'meeting-prep',
+        purpose:
+          'You are called to lookup for information related to the meeting asked, return any information you have and search the knowledge base for any project that could be related',
+      },
+    },
+    measured: {
+      width: 161,
+      height: 42,
+    },
+    selected: false,
+    dragging: false,
+  },
+];
+
+const EDGES: Edge[] = [
+  {
+    source: 'dndnode_1',
+    sourceHandle: 'dndnode_1-right-source',
+    target: 'dndnode_0',
+    targetHandle: 'dndnode_0-left-target',
+    type: 'animated',
+    id: 'xy-edge__dndnode_1dndnode_1-right-source-dndnode_0dndnode_0-left-target',
+  },
+  {
+    source: 'dndnode_2',
+    sourceHandle: 'dndnode_2-right-source',
+    target: 'dndnode_0',
+    targetHandle: 'dndnode_0-left-target',
+    type: 'animated',
+    id: 'xy-edge__dndnode_2dndnode_2-right-source-dndnode_0dndnode_0-left-target',
+  },
+  {
+    source: 'dndnode_0',
+    sourceHandle: 'dndnode_0-right-source',
+    target: 'dndnode_3',
+    targetHandle: 'dndnode_3-left-target',
+    type: 'animated',
+    id: 'xy-edge__dndnode_0dndnode_0-right-source-dndnode_3dndnode_3-left-target',
+  },
+];

--- a/src/features/canva/index.tsx
+++ b/src/features/canva/index.tsx
@@ -22,6 +22,7 @@ import AnimationControls from '@/features/graph/animated-controls';
 import AnimatedEdge from '@/features/graph/animated-edge';
 import RightPanel from '@/features/right-panel';
 
+import { meetingPrepNodes } from './complex/meeting-prep';
 import AgentNode from './nodes/agent';
 import LLMNode from './nodes/llm';
 import MainAgentNode from './nodes/main-agent';
@@ -86,6 +87,14 @@ const DnDFlow = () => {
         y: event.clientY,
       });
 
+      if (nodeData.id === 'meeting-prep') {
+        const { nodes: meetingNodes, edges: meetingEdges } = meetingPrepNodes(getId());
+        setNodes((nds) => nds.concat(meetingNodes));
+        setEdges((eds) => eds.concat(meetingEdges));
+
+        return;
+      }
+
       const newNode: Node = {
         id: getId(),
         type: nodeData.type,
@@ -95,7 +104,7 @@ const DnDFlow = () => {
 
       setNodes((nds) => nds.concat(newNode));
     },
-    [screenToFlowPosition, setNodes]
+    [screenToFlowPosition, setNodes, setEdges]
   );
 
   const handleToggleAnimation = useCallback(

--- a/src/features/canva/index.tsx
+++ b/src/features/canva/index.tsx
@@ -34,7 +34,7 @@ const initialNodes: Node[] = [
     id: '1',
     type: 'main-agent',
     data: MAIN_AGENT,
-    position: { x: 0, y: 0 },
+    position: { x: 600, y: -155 },
     draggable: false,
     deletable: false,
   },


### PR DESCRIPTION
This pull request introduces a new "Meeting Prep" feature to the application, allowing users to prepare for meetings by retrieving relevant information from meeting history and searching a project knowledge base. The changes include adding a new agent node, defining its behavior, and integrating it into the existing canvas flow.

### New Feature: Meeting Preparation

* **Addition of "Meeting Prep" agent node**: A new agent node (`meeting-prep`) is added to `src/const/nodes.tsx` with details such as name, description, icon, and configuration for using OpenAI as the LLM.
* **Implementation of `meetingPrepNodes` function**: A utility function is introduced in `src/features/canva/complex/meeting-prep.tsx` to generate nodes and edges for the "Meeting Prep" feature, including specific tools like `LookupMeetingHistory`, `SearchProjectKB`, and `CallPrepAgent`.

### Integration with Canvas Flow

* **Importing `meetingPrepNodes`**: The `meetingPrepNodes` function is imported into `src/features/canva/index.tsx` to enable its use in the canvas flow.
* **Dynamic addition of "Meeting Prep" nodes and edges**: Logic is added to the `DnDFlow` component to dynamically add the "Meeting Prep" nodes and edges when the corresponding node is dragged onto the canvas.
* **State management update**: The `setEdges` function is added to the dependency array of the `onDragStop` callback to ensure proper state updates.

### UI Adjustment

* **Position adjustment for the main agent node**: The position of the main agent node is updated to better accommodate the new "Meeting Prep" feature on the canvas.